### PR TITLE
Fix Acknowledgements Title In README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -134,6 +134,7 @@ Tired of passing props down a deep tree and want something like React context/ho
     '''))
     # '<h1>My Todos</h1><ul><li>Item: first</li></ul>'
 
-# Acknowledgments
+Acknowledgments
+===============
 
 The idea and code for ``viewdom`` -- the rendering, the idea of a theadlocal context, obviously ``tagged`` and ``htm``... essentially everything -- come from `Joachim Viide <https://github.com/jviide>`_.


### PR DESCRIPTION
Not really sure why the last line is modified. Maybe the GitHub editor added a missing newline at the end?